### PR TITLE
ci: Add an auto-upgrade job for upstream Meltano plugins

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,40 @@
+name: Meltano Lock Update
+
+on:
+  schedule:
+  - cron: '37 */24 * * *'
+  workflow_dispatch: {}
+
+env:
+  MELTANO_CLI_LOG_LEVEL: ${{ github.event.inputs.logLevel || 'warning' }}
+
+jobs:
+  meltano-lock:
+    name: Meltano Lock Update
+    runs-on: ubuntu-latest
+    container:
+      image: registry.gitlab.com/meltano/legacy-ci/meltano:3d25cf64271025d2eaffa0b44b8b58537fbe935e-python3.9
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3.0.2
+
+    - name: Check Meltano
+      run: |
+        meltano --version
+
+    - name: Meltano Lock Update
+      run: |
+        meltano lock --update --all
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4.0.4
+      with:
+        title: 'chore: Update Meltano Plugins'
+        branch: meltano-lock-update
+        commit-message: 'chore: Update Meltano Plugins'
+        delete-branch: true
+        reviewers: edgarrmondragon
+        assignees: edgarrmondragon
+        body: |
+          Created with `meltano lock --update --all`

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,6 +8,10 @@ on:
 env:
   MELTANO_CLI_LOG_LEVEL: ${{ github.event.inputs.logLevel || 'warning' }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   meltano-lock:
     name: Meltano Lock Update


### PR DESCRIPTION
How to test this workflow:

1. > The **Allow GitHub Actions to create and approve pull requests** setting can be managed by admins in organization settings under Actions > General > Workflow permissions.
1. `gh workflow run --ref auto-meltano-lock-update`