### PR TITLE
fix: Skip daily reads chart if there's no data

### DIFF
--- a/evidence/pages/reads/index.md
+++ b/evidence/pages/reads/index.md
@@ -82,11 +82,19 @@ group by `date`
 order by `date` desc
 ```
 
+{#if daily_reads.length !== 0}
+
 <BarChart
     data={data.daily_reads}
     x=date
     y=total
 />
+
+{:else }
+
+No reads in the last 7 days.
+
+{/if}
 
 ## Tags
 


### PR DESCRIPTION
<blockquote>

<p>The command <code>npm run build:strict</code> is a much less permissive build command. Use this to ensure you never deploy a broken report.
This command will fail if:</p>

<ul class=""><li><strong>Any SQL query fails.</strong> A successful query returning no rows is <em>not</em> a failure</li><li><strong>Any component renders an error state.</strong> A component passed a valid query returning no rows <em>will</em> fail - you avoid this with a, <a href="/core-concepts/if-else">{#if} statement</a> if needed.</li></ul>

</blockquote>

* https://docs.evidence.dev/deployment/overview#buildstrict
* https://docs.evidence.dev/core-concepts/if-else
